### PR TITLE
Fix login with space in password

### DIFF
--- a/synology_dsm/synology_dsm.py
+++ b/synology_dsm/synology_dsm.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Class to interact with Synology DSM."""
 import socket
+import sys
 import urllib
 import urllib3
 from requests import Session
@@ -238,10 +239,18 @@ class SynologyDSM(object):
         # Execute Request
         try:
             if method == "GET":
-                encoded_params = urllib.parse.urlencode(params, quote_via=urllib.parse.quote)
+                if sys.version_info[0] < 3:
+                    quote = urllib.quote  # pylint: disable=no-member
+                    param_items = params.iteritems()
+                else:
+                    quote = urllib.parse.quote  # pylint: disable=no-member
+                    param_items = params.items()
+                encoded_params = "&".join(
+                    ["%s=%s" % (key, quote(str(value))) for key, value in param_items]
+                )
                 resp = self._session.get(url, params=encoded_params, **kwargs)
             elif method == "POST":
-                resp = self._session.post(url, pararms=params **kwargs)
+                resp = self._session.post(url, pararms=params ** kwargs)
 
             self._debuglog("Request url: " + resp.url)
             self._debuglog("Request status_code: " + str(resp.status_code))

--- a/synology_dsm/synology_dsm.py
+++ b/synology_dsm/synology_dsm.py
@@ -243,8 +243,12 @@ class SynologyDSM(object):
         # Execute Request
         try:
             if method == "GET":
+                if six.PY2:
+                    items = params.iteritems()
+                else:
+                    items = params.items()
                 encoded_params = "&".join(
-                    "%s=%s" % (key, quote(value)) for key, value in params.iteritems()
+                    "%s=%s" % (key, quote(str(value))) for key, value in items
                 )
                 resp = self._session.get(url, params=encoded_params, **kwargs)
             elif method == "POST":

--- a/synology_dsm/synology_dsm.py
+++ b/synology_dsm/synology_dsm.py
@@ -250,7 +250,7 @@ class SynologyDSM(object):
                 )
                 resp = self._session.get(url, params=encoded_params, **kwargs)
             elif method == "POST":
-                resp = self._session.post(url, pararms=params ** kwargs)
+                resp = self._session.post(url, pararms=params, **kwargs)
 
             self._debuglog("Request url: " + resp.url)
             self._debuglog("Request status_code: " + str(resp.status_code))

--- a/synology_dsm/synology_dsm.py
+++ b/synology_dsm/synology_dsm.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 """Class to interact with Synology DSM."""
 import socket
-import sys
-import urllib
 import urllib3
+import six
 from requests import Session
 from requests.exceptions import RequestException
 from simplejson.errors import JSONDecodeError
@@ -24,6 +23,11 @@ from .api.core.utilization import SynoCoreUtilization
 from .api.dsm.information import SynoDSMInformation
 from .api.dsm.network import SynoDSMNetwork
 from .api.storage.storage import SynoStorage
+
+if six.PY2:
+    from future.moves.urllib.parse import quote
+else:
+    from urllib.parse import quote  # pylint: disable=import-error,no-name-in-module
 
 
 class SynologyDSM(object):
@@ -239,14 +243,8 @@ class SynologyDSM(object):
         # Execute Request
         try:
             if method == "GET":
-                if sys.version_info[0] < 3:
-                    quote = urllib.quote  # pylint: disable=no-member
-                    param_items = params.iteritems()
-                else:
-                    quote = urllib.parse.quote  # pylint: disable=no-member
-                    param_items = params.items()
                 encoded_params = "&".join(
-                    ["%s=%s" % (key, quote(str(value))) for key, value in param_items]
+                    "%s=%s" % (key, quote(value)) for key, value in params.iteritems()
                 )
                 resp = self._session.get(url, params=encoded_params, **kwargs)
             elif method == "POST":

--- a/synology_dsm/synology_dsm.py
+++ b/synology_dsm/synology_dsm.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Class to interact with Synology DSM."""
 import socket
+import urllib
 import urllib3
 from requests import Session
 from requests.exceptions import RequestException
@@ -232,14 +233,15 @@ class SynologyDSM(object):
 
         return response
 
-    def _execute_request(self, method, url, **kwargs):
+    def _execute_request(self, method, url, params, **kwargs):
         """Function to execute and handle a request."""
         # Execute Request
         try:
             if method == "GET":
-                resp = self._session.get(url, **kwargs)
+                encoded_params = urllib.parse.urlencode(params, quote_via=urllib.parse.quote)
+                resp = self._session.get(url, params=encoded_params, **kwargs)
             elif method == "POST":
-                resp = self._session.post(url, **kwargs)
+                resp = self._session.post(url, pararms=params **kwargs)
 
             self._debuglog("Request url: " + resp.url)
             self._debuglog("Request status_code: " + str(resp.status_code))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -116,8 +116,8 @@ class SynologyDSMMock(SynologyDSM):
         self.dsm_version = 6  # 5 or 6
         self.disks_redundancy = "RAID"  # RAID or SHR[number][_EXPANSION]
 
-    def _execute_request(self, method, url, **kwargs):
-        url += urlencode(kwargs["params"])
+    def _execute_request(self, method, url, params, **kwargs):
+        url += urlencode(params)
 
         if "no_internet" in url:
             raise SynologyDSMRequestException(


### PR DESCRIPTION
By default, the `request` package encoded space in url parameters into `+`. However, DSM expects `%20`.

In order to f!x home-assistant/core#35179.