### PR TITLE
Refactor update: @property does not make I/O, use update() for each API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,10 @@ Store the ``device_token`` property so that you do not need to reconnect with pa
 Code exemple
 ------------
 
+Every API has an ``update()`` function that is needed to get the first data, then the data is cached and updated at the next ``update()`` call.
+
+The ``SynologyDSM`` class can also ``update()`` all APIs at once.
+
 .. code-block:: python
 
     from synology_dsm import SynologyDSM
@@ -80,6 +84,7 @@ Code exemple
     api = SynologyDSM("<IP/DNS>", "<port>", "<username>", "<password>")
 
     print("=== Information ===")
+    api.information.update()
     print("Model:           " + str(api.information.model))
     print("RAM:             " + str(api.information.ram) + " MB")
     print("Serial number:   " + str(api.information.serial))
@@ -89,12 +94,14 @@ Code exemple
     print("Full DSM version:" + str(api.information.version_string))
 
     print("=== Utilisation ===")
+    api.utilisation.update()
     print("CPU Load:        " + str(api.utilisation.cpu_total_load) + " %")
     print("Memory Use:      " + str(api.utilisation.memory_real_usage) + " %")
     print("Net Up:          " + str(api.utilisation.network_up()))
     print("Net Down:        " + str(api.utilisation.network_down()))
     
     print("=== Storage ===")
+    api.storage.update()
     for volume_id in api.storage.volumes_ids:
         print("ID:          " + str(volume_id))
         print("Status:      " + str(api.storage.volume_status(volume_id)))

--- a/synology_dsm/api/core/security.py
+++ b/synology_dsm/api/core/security.py
@@ -7,12 +7,13 @@ class SynoCoreSecurity(object):
 
     API_KEY = "SYNO.Core.SecurityScan.Status"
 
-    def __init__(self, raw_data):
+    def __init__(self, dsm):
+        self._dsm = dsm
         self._data = {}
-        self.update(raw_data)
 
-    def update(self, raw_data):
+    def update(self):
         """Updates security data."""
+        raw_data = self._dsm.get(self.API_KEY, "system_get")
         if raw_data:
             self._data = raw_data["data"]
 

--- a/synology_dsm/api/core/utilization.py
+++ b/synology_dsm/api/core/utilization.py
@@ -8,12 +8,13 @@ class SynoCoreUtilization(object):
 
     API_KEY = "SYNO.Core.System.Utilization"
 
-    def __init__(self, raw_data):
+    def __init__(self, dsm):
+        self._dsm = dsm
         self._data = {}
-        self.update(raw_data)
 
-    def update(self, raw_data):
+    def update(self):
         """Updates utilization data."""
+        raw_data = self._dsm.get(self.API_KEY, "get")
         if raw_data:
             self._data = raw_data["data"]
 

--- a/synology_dsm/api/dsm/information.py
+++ b/synology_dsm/api/dsm/information.py
@@ -7,12 +7,13 @@ class SynoDSMInformation(object):
 
     API_KEY = "SYNO.DSM.Info"
 
-    def __init__(self, raw_data):
+    def __init__(self, dsm):
+        self._dsm = dsm
         self._data = {}
-        self.update(raw_data)
 
-    def update(self, raw_data):
+    def update(self):
         """Updates information data."""
+        raw_data = self._dsm.get(self.API_KEY, "getinfo")
         if raw_data:
             self._data = raw_data["data"]
 

--- a/synology_dsm/api/dsm/network.py
+++ b/synology_dsm/api/dsm/network.py
@@ -7,12 +7,13 @@ class SynoDSMNetwork(object):
 
     API_KEY = "SYNO.DSM.Network"
 
-    def __init__(self, raw_data):
+    def __init__(self, dsm):
+        self._dsm = dsm
         self._data = {}
-        self.update(raw_data)
 
-    def update(self, raw_data):
+    def update(self):
         """Updates network data."""
+        raw_data = self._dsm.get(self.API_KEY, "list")
         if raw_data:
             self._data = raw_data["data"]
 

--- a/synology_dsm/api/storage/storage.py
+++ b/synology_dsm/api/storage/storage.py
@@ -10,12 +10,13 @@ class SynoStorage(object):
 
     API_KEY = "SYNO.Storage.CGI.Storage"
 
-    def __init__(self, raw_data):
+    def __init__(self, dsm):
+        self._dsm = dsm
         self._data = {}
-        self.update(raw_data)
 
-    def update(self, raw_data):
+    def update(self):
         """Updates storage data."""
+        raw_data = self._dsm.get(self.API_KEY, "load_info")
         if raw_data:
             self._data = raw_data
             if raw_data.get("data"):

--- a/synology_dsm/synology_dsm.py
+++ b/synology_dsm/synology_dsm.py
@@ -166,8 +166,8 @@ class SynologyDSM(object):
         self._debuglog("Authentication successful, token: " + str(self._session_id))
 
         if not self._information:
-            data = self.get(SynoDSMInformation.API_KEY, "getinfo")
-            self._information = SynoDSMInformation(data)
+            self._information = SynoDSMInformation(self)
+            self._information.update()
 
         return True
 
@@ -288,23 +288,22 @@ class SynologyDSM(object):
         except (RequestException, JSONDecodeError) as exp:
             raise SynologyDSMRequestException(exp)
 
-    def update(self, with_information=False):
+    def update(self, with_information=False, with_network=False):
         """Updates the various instanced modules."""
         if self._information and with_information:
-            data = self.get(SynoDSMInformation.API_KEY, "getinfo")
-            self._information.update(data)
+            self._information.update()
+
+        if self._network and with_network:
+            self._network.update()
 
         if self._security:
-            data = self.get(SynoCoreSecurity.API_KEY, "system_get")
-            self._security = SynoCoreSecurity(data)
+            self._security.update()
 
         if self._utilisation:
-            data = self.get(SynoCoreUtilization.API_KEY, "get")
-            self._utilisation.update(data)
+            self._utilisation.update()
 
         if self._storage:
-            data = self.get(SynoStorage.API_KEY, "load_info")
-            self._storage.update(data)
+            self._storage.update()
 
         if self._surveillance:
             self._surveillance.update()
@@ -347,40 +346,35 @@ class SynologyDSM(object):
     def information(self):
         """Gets NAS informations."""
         if not self._information:
-            data = self.get(SynoDSMInformation.API_KEY, "getinfo")
-            self._information = SynoDSMInformation(data)
+            self._information = SynoDSMInformation(self)
         return self._information
 
     @property
     def network(self):
         """Gets NAS network informations."""
         if not self._network:
-            data = self.get(SynoDSMNetwork.API_KEY, "list")
-            self._network = SynoDSMNetwork(data)
+            self._network = SynoDSMNetwork(self)
         return self._network
 
     @property
     def security(self):
         """Gets NAS security informations."""
         if not self._security:
-            data = self.get(SynoCoreSecurity.API_KEY, "system_get")
-            self._security = SynoCoreSecurity(data)
+            self._security = SynoCoreSecurity(self)
         return self._security
 
     @property
     def utilisation(self):
         """Gets NAS utilisation informations."""
         if not self._utilisation:
-            data = self.get(SynoCoreUtilization.API_KEY, "get")
-            self._utilisation = SynoCoreUtilization(data)
+            self._utilisation = SynoCoreUtilization(self)
         return self._utilisation
 
     @property
     def storage(self):
         """Gets NAS storage informations."""
         if not self._storage:
-            data = self.get(SynoStorage.API_KEY, "load_info")
-            self._storage = SynoStorage(data)
+            self._storage = SynoStorage(self)
         return self._storage
 
     @property

--- a/tests/test_synology_dsm.py
+++ b/tests/test_synology_dsm.py
@@ -351,6 +351,7 @@ class TestSynologyDSM(TestCase):
     def test_information(self):
         """Test information."""
         assert self.api.information
+        self.api.information.update()
         assert self.api.information.model == "DS918+"
         assert self.api.information.ram == 4096
         assert self.api.information.serial == "1920PDN001501"
@@ -363,6 +364,7 @@ class TestSynologyDSM(TestCase):
     def test_network(self):
         """Test network."""
         assert self.api.network
+        self.api.network.update()
         assert self.api.network.dns
         assert self.api.network.gateway
         assert self.api.network.hostname
@@ -375,6 +377,7 @@ class TestSynologyDSM(TestCase):
     def test_security(self):
         """Test security, safe status."""
         assert self.api.security
+        self.api.security.update()
         assert self.api.security.checks
         assert self.api.security.last_scan_time
         assert not self.api.security.start_time  # Finished scan
@@ -393,6 +396,7 @@ class TestSynologyDSM(TestCase):
         """Test security, outOfDate status."""
         self.api.error = True
         assert self.api.security
+        self.api.security.update()
         assert self.api.security.checks
         assert self.api.security.last_scan_time
         assert not self.api.security.start_time  # Finished scan
@@ -410,12 +414,13 @@ class TestSynologyDSM(TestCase):
     def test_utilisation(self):
         """Test utilisation."""
         assert self.api.utilisation
+        self.api.utilisation.update()
 
     def test_utilisation_error(self):
         """Test utilisation error."""
         self.api.error = True
         with pytest.raises(SynologyDSMAPIErrorException) as error:
-            assert self.api.utilisation
+            self.api.utilisation.update()
         error_value = error.value.args[0]
         assert error_value["api"] == "SYNO.Core.System.Utilization"
         assert error_value["code"] == 1055
@@ -429,6 +434,7 @@ class TestSynologyDSM(TestCase):
 
     def test_utilisation_cpu(self):
         """Test utilisation CPU."""
+        self.api.utilisation.update()
         assert self.api.utilisation.cpu
         assert self.api.utilisation.cpu_other_load
         assert self.api.utilisation.cpu_user_load
@@ -440,6 +446,7 @@ class TestSynologyDSM(TestCase):
 
     def test_utilisation_memory(self):
         """Test utilisation memory."""
+        self.api.utilisation.update()
         assert self.api.utilisation.memory
         assert self.api.utilisation.memory_real_usage
         assert self.api.utilisation.memory_size()
@@ -457,6 +464,7 @@ class TestSynologyDSM(TestCase):
 
     def test_utilisation_network(self):
         """Test utilisation network."""
+        self.api.utilisation.update()
         assert self.api.utilisation.network
         assert self.api.utilisation.network_up()
         assert self.api.utilisation.network_up(True)
@@ -466,6 +474,7 @@ class TestSynologyDSM(TestCase):
     def test_storage(self):
         """Test storage roots."""
         assert self.api.storage
+        self.api.storage.update()
         assert self.api.storage.disks
         assert self.api.storage.env
         assert self.api.storage.storage_pools
@@ -473,6 +482,7 @@ class TestSynologyDSM(TestCase):
 
     def test_storage_raid_volumes(self):
         """Test RAID storage volumes."""
+        self.api.storage.update()
         # Basics
         assert self.api.storage.volumes_ids
         for volume_id in self.api.storage.volumes_ids:
@@ -524,6 +534,7 @@ class TestSynologyDSM(TestCase):
     def test_storage_shr_volumes(self):
         """Test SHR storage volumes."""
         self.api.disks_redundancy = "SHR1"
+        self.api.storage.update()
 
         # Basics
         assert self.api.storage.volumes_ids
@@ -592,6 +603,7 @@ class TestSynologyDSM(TestCase):
     def test_storage_shr2_volumes(self):
         """Test SHR2 storage volumes."""
         self.api.disks_redundancy = "SHR2"
+        self.api.storage.update()
 
         # Basics
         assert self.api.storage.volumes_ids
@@ -622,6 +634,7 @@ class TestSynologyDSM(TestCase):
     def test_storage_shr2_expansion_volumes(self):
         """Test SHR2 storage with expansion unit volumes."""
         self.api.disks_redundancy = "SHR2_EXPANSION"
+        self.api.storage.update()
 
         # Basics
         assert self.api.storage.volumes_ids
@@ -651,6 +664,7 @@ class TestSynologyDSM(TestCase):
 
     def test_storage_disks(self):
         """Test storage disks."""
+        self.api.storage.update()
         # Basics
         assert self.api.storage.disks_ids
         for disk_id in self.api.storage.disks_ids:

--- a/tests/test_synology_dsm_5.py
+++ b/tests/test_synology_dsm_5.py
@@ -201,6 +201,7 @@ class TestSynologyDSM(TestCase):
     def test_information(self):
         """Test information."""
         assert self.api.information
+        self.api.information.update()
         assert self.api.information.model == "DS3615xs"
         assert self.api.information.ram == 6144
         assert self.api.information.serial == "B3J4N01003"
@@ -213,6 +214,7 @@ class TestSynologyDSM(TestCase):
     def test_network(self):
         """Test network."""
         assert self.api.network
+        self.api.network.update()
         assert self.api.network.dns
         assert self.api.network.gateway
         assert self.api.network.hostname
@@ -225,9 +227,11 @@ class TestSynologyDSM(TestCase):
     def test_utilisation(self):
         """Test utilization."""
         assert self.api.utilisation
+        self.api.utilisation.update()
 
     def test_utilisation_cpu(self):
         """Test utilization CPU."""
+        self.api.utilisation.update()
         assert self.api.utilisation.cpu
         assert self.api.utilisation.cpu_other_load
         assert self.api.utilisation.cpu_user_load
@@ -239,6 +243,7 @@ class TestSynologyDSM(TestCase):
 
     def test_utilisation_memory(self):
         """Test utilization memory."""
+        self.api.utilisation.update()
         assert self.api.utilisation.memory
         assert self.api.utilisation.memory_real_usage
         assert self.api.utilisation.memory_size()
@@ -256,6 +261,7 @@ class TestSynologyDSM(TestCase):
 
     def test_utilisation_network(self):
         """Test utilization network."""
+        self.api.utilisation.update()
         assert self.api.utilisation.network
         assert self.api.utilisation.network_up()
         assert self.api.utilisation.network_up(True)
@@ -265,6 +271,7 @@ class TestSynologyDSM(TestCase):
     def test_storage(self):
         """Test storage roots."""
         assert self.api.storage
+        self.api.storage.update()
         assert self.api.storage.disks
         assert self.api.storage.env
         assert self.api.storage.storage_pools == []
@@ -272,6 +279,7 @@ class TestSynologyDSM(TestCase):
 
     def test_storage_volumes(self):
         """Test storage volumes."""
+        self.api.storage.update()
         # Basics
         assert self.api.storage.volumes_ids
         for volume_id in self.api.storage.volumes_ids:
@@ -330,6 +338,7 @@ class TestSynologyDSM(TestCase):
 
     def test_storage_disks(self):
         """Test storage disks."""
+        self.api.storage.update()
         # Basics
         assert self.api.storage.disks_ids
         for disk_id in self.api.storage.disks_ids:


### PR DESCRIPTION
Breaking change: `update()` is necesary before accessing the first data.