### PR TITLE
Fix Surveillance Station update when no camera linked

### DIFF
--- a/synology_dsm/api/surveillance_station/__init__.py
+++ b/synology_dsm/api/surveillance_station/__init__.py
@@ -37,6 +37,9 @@ class SynoSurveillanceStation:
                 )["data"]
             )
 
+        if not self._cameras_by_id:
+            return
+
         live_view_datas = self._dsm.get(
             self.CAMERA_API_KEY,
             "GetLiveViewPath",


### PR DESCRIPTION
In order to f!x home-assistant/core#41416

Fix:
```
  File "/Users/pollet/dev/home-assistant/core/venv/lib/python3.8/site-packages/synology_dsm/api/surveillance_station/__init__.py", line 46, in update
    live_view_data = self._dsm.get(
  File "/Users/pollet/dev/home-assistant/core/venv/lib/python3.8/site-packages/synology_dsm/synology_dsm.py", line 186, in get
    return self._request("GET", api, method, params, **kwargs)
  File "/Users/pollet/dev/home-assistant/core/venv/lib/python3.8/site-packages/synology_dsm/synology_dsm.py", line 247, in _request
    raise SynologyDSMAPIErrorException(
synology_dsm.exceptions.SynologyDSMAPIErrorException: {'api': 'SYNO.SurveillanceStation.Camera', 'code': 401, 'reason': 'Invalid parameter', 'details': None}
```